### PR TITLE
✨ feat: 支持 18 以下的 React 版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@floating-ui/react": "^0.17",
     "animated-scroll-to": "^2",
     "antd-style": "beta",
+    "ahooks": "^3",
     "chalk": "^4",
     "chroma-js": "^2",
     "copy-to-clipboard": "^3",


### PR DESCRIPTION
目前主题包的 `peerDependencies` 仅要求 `"react": ">=16.8"`

但因为 `src\components\StoreUpdater.tsx` 文件内使用了 `React.startTransition` 方法，目前主题包实际上必须依赖 `react 18+`

此 PR 主要提供 16、17 版本 React 支持，参见 #10 