### PR TITLE
feat: add tree component

### DIFF
--- a/example/docs/components/Tree.en-US.md
+++ b/example/docs/components/Tree.en-US.md
@@ -1,0 +1,124 @@
+---
+order: 2
+title: Tree Reference
+atomId: Tree
+description: Render Tree component
+group: Functional Components
+---
+ 
+Integrated with [litetree](https://zhangfisher.github.io/lite-tree/), it is very easy render tree component in in documents.
+
+The tree structure can be represented simply by using indentation, supporting various icons, colors, styles, etc.
+
+```md
+<Tree>
+ROOT
+    A
+        A1
+            A11
+            A12
+        A2
+            A21
+            A22
+    B
+        + B1
+            B11
+            B12
+        + B2
+            B21
+            B22  
+</Tree>
+```
+
+Rendering effect is as follows:
+
+<Tree>
+ROOT
+    A
+        A1
+            A11
+            A12
+        A2
+            A21
+            A22
+    B
+        + B1
+            B11
+            B12
+        + B2
+            B21
+            B22  
+</Tree>
+
+Supports a variety of features, such as:
+
+```md
+<Tree> 
+#error=color:red;border: 1px solid red;background:#ffd2d2;padding:2px;
+#blue=color:red;border: 1px solid blue;background:#e6e6ff;padding:2px;
+airplane=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjU2IDI1NiI+PHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMjM1LjU4IDEyOC44NEwxNjAgOTEuMDZWNDhhMzIgMzIgMCAwIDAtNjQgMHY0My4wNmwtNzUuNTggMzcuNzhBOCA4IDAgMCAwIDE2IDEzNnYzMmE4IDggMCAwIDAgOS41NyA3Ljg0TDk2IDE2MS43NnYxOC45M2wtMTMuNjYgMTMuNjVBOCA4IDAgMCAwIDgwIDIwMHYzMmE4IDggMCAwIDAgMTEgNy40M2wzNy0xNC44MWwzNyAxNC44MWE4IDggMCAwIDAgMTEtNy40M3YtMzJhOCA4IDAgMCAwLTIuMzQtNS42NkwxNjAgMTgwLjY5di0xOC45M2w3MC40MyAxNC4wOEE4IDggMCAwIDAgMjQwIDE2OHYtMzJhOCA4IDAgMCAwLTQuNDItNy4xNk0yMjQgMTU4LjI0bC03MC40My0xNC4wOEE4IDggMCAwIDAgMTQ0IDE1MnYzMmE4IDggMCAwIDAgMi4zNCA1LjY2TDE2MCAyMDMuMzF2MTYuODdsLTI5LTExLjYxYTggOCAwIDAgMC01Ljk0IDBMOTYgMjIwLjE4di0xNi44N2wxMy42Ni0xMy42NUE4IDggMCAwIDAgMTEyIDE4NHYtMzJhOCA4IDAgMCAwLTkuNTctNy44NEwzMiAxNTguMjR2LTE3LjNsNzUuNTgtMzcuNzhBOCA4IDAgMCAwIDExMiA5NlY0OGExNiAxNiAwIDAgMSAzMiAwdjQ4YTggOCAwIDAgMCA0LjQyIDcuMTZMMjI0IDE0MC45NFoiLz48L3N2Zz4=
+ts=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMTUgMTUiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBkPSJNMTIuNSA4di0uMTY3YzAtLjczNi0uNTk3LTEuMzMzLTEuMzMzLTEuMzMzSDEwYTEuNSAxLjUgMCAxIDAgMCAzaDFhMS41IDEuNSAwIDAgMSAwIDNoLTFBMS41IDEuNSAwIDAgMSA4LjUgMTFNOCA2LjVIM20yLjUgMFYxM00uNS41aDE0djE0SC41eiIvPjwvc3ZnPg==
+---
+- [airplane]Company A({color:red;}Key,{#blue}Urgent)          //   Company Name
+    Administrative Center
+        {color:red;font-weight:bold;background:#ffeaea}President's Office
+        [checked]Human Resources Department
+        [unchecked]{.blue}Finance Department
+        Administrative Department        //+  Responsible for administrative management
+        Legal Department                //+  Litigation, etc.
+        [airplane]Audit Department      //+  Audit finance[Save:tag](sss) [Link](sss)
+        Information Center              // Key[Save](www.baidu.com)[tag][Link:tag](www.baidu.com)
+        [star]Sec[star]ur[star]ity[star] and [star]Pro[star]tection[star] Department[star]                //{color:red}   Confidentiality work
+    + Market Center    
+        Marketing Department({#error}Error,"{#warning}Warning")
+        Sales Department                //-
+        Customer Service Department     //-
+        {#blue}Brand Department         //   this is cool
+        Market Planning Department      //!  Key
+        Market Marketing Department     // {.blue}this is cool
+    R&D Center
+        Mobile R&D Department           //! 
+        Platform R&D Department({success}Java,{error}Go)
+        {.success}Testing Department
+        Operations Department
+        Product Department                //*
+        Design Department                 //*
+        Project Management Department     //*
+</Tree>      
+```
+
+Rendering effect is as follows:
+<Tree>
+#error=color:red;border: 1px solid red;background:#ffd2d2;padding:2px;
+#blue=color:red;border: 1px solid blue;background:#e6e6ff;padding:2px;
+airplane=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjU2IDI1NiI+PHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMjM1LjU4IDEyOC44NEwxNjAgOTEuMDZWNDhhMzIgMzIgMCAwIDAtNjQgMHY0My4wNmwtNzUuNTggMzcuNzhBOCA4IDAgMCAwIDE2IDEzNnYzMmE4IDggMCAwIDAgOS41NyA3Ljg0TDk2IDE2MS43NnYxOC45M2wtMTMuNjYgMTMuNjVBOCA4IDAgMCAwIDgwIDIwMHYzMmE4IDggMCAwIDAgMTEgNy40M2wzNy0xNC44MWwzNyAxNC44MWE4IDggMCAwIDAgMTEtNy40M3YtMzJhOCA4IDAgMCAwLTIuMzQtNS42NkwxNjAgMTgwLjY5di0xOC45M2w3MC40MyAxNC4wOEE4IDggMCAwIDAgMjQwIDE2OHYtMzJhOCA4IDAgMCAwLTQuNDItNy4xNk0yMjQgMTU4LjI0bC03MC40My0xNC4wOEE4IDggMCAwIDAgMTQ0IDE1MnYzMmE4IDggMCAwIDAgMi4zNCA1LjY2TDE2MCAyMDMuMzF2MTYuODdsLTI5LTExLjYxYTggOCAwIDAgMC01Ljk0IDBMOTYgMjIwLjE4di0xNi44N2wxMy42Ni0xMy42NUE4IDggMCAwIDAgMTEyIDE4NHYtMzJhOCA4IDAgMCAwLTkuNTctNy44NEwzMiAxNTguMjR2LTE3LjNsNzUuNTgtMzcuNzhBOCA4IDAgMCAwIDExMiA5NlY0OGExNiAxNiAwIDAgMSAzMiAwdjQ4YTggOCAwIDAgMCA0LjQyIDcuMTZMMjI0IDE0MC45NFoiLz48L3N2Zz4=
+ts=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMTUgMTUiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBkPSJNMTIuNSA4di0uMTY3YzAtLjczNi0uNTk3LTEuMzMzLTEuMzMzLTEuMzMzSDEwYTEuNSAxLjUgMCAxIDAgMCAzaDFhMS41IDEuNSAwIDAgMSAwIDNoLTFBMS41IDEuNSAwIDAgMSA4LjUgMTFNOCA2LjVIM20yLjUgMFYxM00uNS41aDE0djE0SC41eiIvPjwvc3ZnPg==
+---
+- [airplane]Company A({color:red;}Key,{#blue}Urgent)          //   Company Name
+    Administrative Center
+        {color:red;font-weight:bold;background:#ffeaea}President's Office
+        [checked]Human Resources Department
+        [unchecked]{.blue}Finance Department
+        Administrative Department        //+  Responsible for administrative management
+        Legal Department                //+  Litigation, etc.
+        [airplane]Audit Department      //+  Audit finance[Save:tag](sss) [Link](sss)
+        Information Center              // Key[Save](www.baidu.com)[tag][Link:tag](www.baidu.com)
+        [star]Sec[star]ur[star]ity[star] and [star]Pro[star]tection[star] Department[star]                //{color:red}   Confidentiality work
+    + Market Center    
+        Marketing Department({#error}Error,"{#warning}Warning")
+        Sales Department                //-
+        Customer Service Department     //-
+        {#blue}Brand Department         //   this is cool
+        Market Planning Department      //!  Key
+        Market Marketing Department     // {.blue}this is cool
+    R&D Center
+        Mobile R&D Department           //! 
+        Platform R&D Department({success}Java,{error}Go)
+        {.success}Testing Department
+        Operations Department
+        Product Department                //*
+        Design Department                 //*
+        Project Management Department     //*
+</Tree>     
+
+Above is the basic usage of `Tree`. For more information about `Tree`, please visit [litetree](https://zhangfisher.github.io/lite-tree/).

--- a/example/docs/components/Tree.zh-CN.md
+++ b/example/docs/components/Tree.zh-CN.md
@@ -1,0 +1,126 @@
+---
+order: 2
+title: Tree 树
+atomId: Tree
+description: 渲染树形结构的组件
+group: 功能组件
+---
+
+
+集成[litetree](https://zhangfisher.github.io/lite-tree/)，可以非常方便地在文档中使用树组件。
+
+> 只需要采用缩进方式就可以表示树的结构，支持多种图标、颜色、样式等。
+
+```md
+<Tree>
+ROOT
+    A
+        A1
+            A11
+            A12
+        A2
+            A21
+            A22
+    B
+        + B1
+            B11
+            B12
+        + B2
+            B21
+            B22  
+</Tree>
+```
+
+渲染效果如下：
+
+<Tree>
+ROOT
+    A
+        A1
+            A11
+            A12
+        A2
+            A21
+            A22
+    B
+        + B1
+            B11
+            B12
+        + B2
+            B21
+            B22  
+</Tree>
+
+也支持非常丰富的特性，如下：
+
+```md
+<Tree>
+#error=color:red;border: 1px solid red;background:#ffd2d2;padding:2px;
+#blue=color:red;border: 1px solid blue;background:#e6e6ff;padding:2px;
+airplane=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjU2IDI1NiI+PHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMjM1LjU4IDEyOC44NEwxNjAgOTEuMDZWNDhhMzIgMzIgMCAwIDAtNjQgMHY0My4wNmwtNzUuNTggMzcuNzhBOCA4IDAgMCAwIDE2IDEzNnYzMmE4IDggMCAwIDAgOS41NyA3Ljg0TDk2IDE2MS43NnYxOC45M2wtMTMuNjYgMTMuNjVBOCA4IDAgMCAwIDgwIDIwMHYzMmE4IDggMCAwIDAgMTEgNy40M2wzNy0xNC44MWwzNyAxNC44MWE4IDggMCAwIDAgMTEtNy40M3YtMzJhOCA4IDAgMCAwLTIuMzQtNS42NkwxNjAgMTgwLjY5di0xOC45M2w3MC40MyAxNC4wOEE4IDggMCAwIDAgMjQwIDE2OHYtMzJhOCA4IDAgMCAwLTQuNDItNy4xNk0yMjQgMTU4LjI0bC03MC40My0xNC4wOEE4IDggMCAwIDAgMTQ0IDE1MnYzMmE4IDggMCAwIDAgMi4zNCA1LjY2TDE2MCAyMDMuMzF2MTYuODdsLTI5LTExLjYxYTggOCAwIDAgMC01Ljk0IDBMOTYgMjIwLjE4di0xNi44N2wxMy42Ni0xMy42NUE4IDggMCAwIDAgMTEyIDE4NHYtMzJhOCA4IDAgMCAwLTkuNTctNy44NEwzMiAxNTguMjR2LTE3LjNsNzUuNTgtMzcuNzhBOCA4IDAgMCAwIDExMiA5NlY0OGExNiAxNiAwIDAgMSAzMiAwdjQ4YTggOCAwIDAgMCA0LjQyIDcuMTZMMjI0IDE0MC45NFoiLz48L3N2Zz4=
+ts=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMTUgMTUiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBkPSJNMTIuNSA4di0uMTY3YzAtLjczNi0uNTk3LTEuMzMzLTEuMzMzLTEuMzMzSDEwYTEuNSAxLjUgMCAxIDAgMCAzaDFhMS41IDEuNSAwIDAgMSAwIDNoLTFBMS41IDEuNSAwIDAgMSA4LjUgMTFNOCA2LjVIM20yLjUgMFYxM00uNS41aDE0djE0SC41eiIvPjwvc3ZnPg==
+---
+- [airplane]A公司({color:red;}重点,{#blue}紧急)          //   企业名称
+    行政中心
+        {color:red;font-weight:bold;background:#ffeaea}总裁办
+        [checked]人力资源部
+        [unchecked]{.blue}财务部
+        行政部        //+  负责行政管理
+        法务部        //+  打官司等
+        [airplane]审计部        //+  审计财务[保存:tag](sss) [连接](sss)
+        信息中心      // 重点[保存](www.baidu.com)[tag][连接:tag](www.baidu.com)
+        [star]安[star]全[star]保[star]卫[star]部[star]    //{color:red}   保密工作
+    + 市场中心    
+        市场部({#error}出错,"{#warning}警告")
+        销售部            //-
+        客服部            //-
+        {#blue}品牌部            //   this is cool
+        市场策划部    //!  重点
+        市场营销部        // {.blue}this is cool
+    研发中心
+        移动研发部      //!
+        平台研发部({success}Java,{error}Go)
+        {.success}测试部
+        运维部
+        产品部            //*
+        设计部            //*
+        项目管理部        //*
+</Tree>
+```
+
+渲染效果如下：
+
+<Tree>
+#error=color:red;border: 1px solid red;background:#ffd2d2;padding:2px;
+#blue=color:red;border: 1px solid blue;background:#e6e6ff;padding:2px;
+airplane=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjU2IDI1NiI+PHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMjM1LjU4IDEyOC44NEwxNjAgOTEuMDZWNDhhMzIgMzIgMCAwIDAtNjQgMHY0My4wNmwtNzUuNTggMzcuNzhBOCA4IDAgMCAwIDE2IDEzNnYzMmE4IDggMCAwIDAgOS41NyA3Ljg0TDk2IDE2MS43NnYxOC45M2wtMTMuNjYgMTMuNjVBOCA4IDAgMCAwIDgwIDIwMHYzMmE4IDggMCAwIDAgMTEgNy40M2wzNy0xNC44MWwzNyAxNC44MWE4IDggMCAwIDAgMTEtNy40M3YtMzJhOCA4IDAgMCAwLTIuMzQtNS42NkwxNjAgMTgwLjY5di0xOC45M2w3MC40MyAxNC4wOEE4IDggMCAwIDAgMjQwIDE2OHYtMzJhOCA4IDAgMCAwLTQuNDItNy4xNk0yMjQgMTU4LjI0bC03MC40My0xNC4wOEE4IDggMCAwIDAgMTQ0IDE1MnYzMmE4IDggMCAwIDAgMi4zNCA1LjY2TDE2MCAyMDMuMzF2MTYuODdsLTI5LTExLjYxYTggOCAwIDAgMC01Ljk0IDBMOTYgMjIwLjE4di0xNi44N2wxMy42Ni0xMy42NUE4IDggMCAwIDAgMTEyIDE4NHYtMzJhOCA4IDAgMCAwLTkuNTctNy44NEwzMiAxNTguMjR2LTE3LjNsNzUuNTgtMzcuNzhBOCA4IDAgMCAwIDExMiA5NlY0OGExNiAxNiAwIDAgMSAzMiAwdjQ4YTggOCAwIDAgMCA0LjQyIDcuMTZMMjI0IDE0MC45NFoiLz48L3N2Zz4=
+ts=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMTUgMTUiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBkPSJNMTIuNSA4di0uMTY3YzAtLjczNi0uNTk3LTEuMzMzLTEuMzMzLTEuMzMzSDEwYTEuNSAxLjUgMCAxIDAgMCAzaDFhMS41IDEuNSAwIDAgMSAwIDNoLTFBMS41IDEuNSAwIDAgMSA4LjUgMTFNOCA2LjVIM20yLjUgMFYxM00uNS41aDE0djE0SC41eiIvPjwvc3ZnPg==
+---
+- [airplane]A公司({color:red;}重点,{#blue}紧急)          //   企业名称
+    行政中心
+        {color:red;font-weight:bold;background:#ffeaea}总裁办
+        [checked]人力资源部
+        [unchecked]{.blue}财务部
+        行政部        //+  负责行政管理
+        法务部        //+  打官司等
+        [airplane]审计部        //+  审计财务[保存:tag](sss) [连接](sss)
+        信息中心      // 重点[保存](www.baidu.com)[tag][连接:tag](www.baidu.com)
+        [star]安[star]全[star]保[star]卫[star]部[star]    //{color:red}   保密工作
+    + 市场中心    
+        市场部({#error}出错,"{#warning}警告")
+        销售部            //-
+        客服部            //-
+        {#blue}品牌部            //   this is cool
+        市场策划部    //!  重点
+        市场营销部        // {.blue}this is cool
+    研发中心
+        移动研发部      //!
+        平台研发部({success}Java,{error}Go)
+        {.success}测试部
+        运维部
+        产品部            //*
+        设计部            //*
+        项目管理部        //*
+</Tree>
+
+关于`Tree`更多使用，请访问[litetree](https://zhangfisher.github.io/lite-tree/)。

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "swr": "^2.2.5",
     "use-merge-value": "^1",
     "zustand": "^4.4.1",
-    "zustand-utils": "^1"
+    "zustand-utils": "^1",
+    "@lite-tree/react": "^1.1.4"
   },
   "devDependencies": {
     "@commitlint/cli": "^17",

--- a/src/builtins/Tree/index.tsx
+++ b/src/builtins/Tree/index.tsx
@@ -1,0 +1,3 @@
+import { LiteTree } from '@lite-tree/react';
+
+export default LiteTree;


### PR DESCRIPTION
`dumi`内置的树渲染采用`<ul>/<li>`的方式进行渲染，优点是兼容性，但是也存在

- 样式单一，表现力偏弱
- 冗余数据太多，复杂一点的树就有点不方便，不是为markdown准备的

本次`PR`引入`LiteTree`，提供内置组件`Tree`，可以非常方便地渲染树

如下:

```md
<Tree>
根节点
    + 节点1                     // 默认展开状态
        - 节点1.1
        - 节点1.2
    - 节点2                     // 默认折叠状态
        - 节点2.1   
        - 节点2.2
</Tree>
```
渲染如下树:

![image](https://github.com/user-attachments/assets/cacd81bf-3cdb-406c-b722-f29baa271979)


关于[LiteTree](https://zhangfisher.github.io/lite-tree/)



